### PR TITLE
[fix]: support linux bundle install

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,9 +35,13 @@ GEM
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
     ffi (1.17.1-arm64-darwin)
+    ffi (1.17.1-x86_64-linux-gnu)
     forwardable-extended (2.6.0)
     gemoji (4.1.0)
     google-protobuf (4.30.2-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.30.2-x86_64-linux)
       bigdecimal
       rake (>= 13)
     html-pipeline (2.14.3)
@@ -106,6 +110,8 @@ GEM
       uri
     nokogiri (1.18.7-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.18.7-x86_64-linux-gnu)
+      racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
@@ -122,6 +128,8 @@ GEM
     safe_yaml (1.0.5)
     sass-embedded (1.86.3-arm64-darwin)
       google-protobuf (~> 4.30)
+    sass-embedded (1.86.3-x86_64-linux-gnu)
+      google-protobuf (~> 4.30)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
@@ -136,6 +144,7 @@ GEM
 
 PLATFORMS
   arm64-darwin
+  x86_64-linux
 
 DEPENDENCIES
   csv

--- a/_posts/2017-11-16-caffe-ssd-bug.md
+++ b/_posts/2017-11-16-caffe-ssd-bug.md
@@ -1,7 +1,7 @@
 ---
 title: "caffe-ssd bug 解决日志"
 date: 2017-11-16 20:56:42
-categories:["DAC-SDC"]
+categories: ["DAC-SDC"]
 tags: ["deeplearning"]
 permalink: "/2017/11/16/caffe-ssd-bug-%e8%a7%a3%e5%86%b3%e6%97%a5%e5%bf%97/"
 legacy: true


### PR DESCRIPTION
Add the x86_64-linux platform gems to the lockfile so GitHub Actions can install dependencies, and fix the malformed front matter that blocked the Jekyll build.